### PR TITLE
TreeModel PMML Export - add Node IDs

### DIFF
--- a/src/main/java/org/jpmml/sparkml/model/DecisionTreeClassificationModelConverter.java
+++ b/src/main/java/org/jpmml/sparkml/model/DecisionTreeClassificationModelConverter.java
@@ -37,6 +37,8 @@ public class DecisionTreeClassificationModelConverter extends ModelConverter<Dec
 		TreeModel treeModel = TreeModelUtil.encodeDecisionTree(model, schema)
 			.setOutput(ModelUtil.createProbabilityOutput(schema));
 
+		TreeModelUtil.indexNodes(treeModel);
+
 		return treeModel;
 	}
 }

--- a/src/main/java/org/jpmml/sparkml/model/TreeModelUtil.java
+++ b/src/main/java/org/jpmml/sparkml/model/TreeModelUtil.java
@@ -125,6 +125,23 @@ public class TreeModelUtil {
 	}
 
 	static
+	public void indexNodes(final TreeModel treeModel) {
+		Visitor treeNodeIndexer = new AbstractVisitor() {
+			int currentIndex = 1;
+
+			@Override
+			public VisitorAction visit(Node node) {
+				node.setId((new Integer(currentIndex)).toString());
+				++currentIndex;
+
+				return super.visit(node);
+			}
+		};
+
+		treeNodeIndexer.applyTo(treeModel);
+	}
+
+	static
 	public Node encodeNode(MiningFunctionType miningFunction, org.apache.spark.ml.tree.Node node, Schema schema){
 
 		if(node instanceof InternalNode){

--- a/src/test/java/org/jpmml/sparkml/VisitorsTest.java
+++ b/src/test/java/org/jpmml/sparkml/VisitorsTest.java
@@ -1,0 +1,67 @@
+package org.jpmml.sparkml;
+
+import org.dmg.pmml.*;
+
+import org.jpmml.model.visitors.AbstractVisitor;
+import org.jpmml.sparkml.model.TreeModelUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class VisitorsTest {
+    TreeModel treeModel;
+    static int numberOfNodes = 7;
+
+    //Build some tree with $numberOfNodes Nodes
+
+    @Before
+    public void buildTreeNodes() {
+        List<Node> nodes = new ArrayList<>();
+
+        for (int i = 0; i < numberOfNodes; ++i) nodes.add(new Node());
+
+        nodes.get(0).addNodes(nodes.get(1), nodes.get(2), nodes.get(3));
+
+        nodes.get(2).addNodes(nodes.get(4));
+        nodes.get(3).addNodes(nodes.get(5));
+
+        nodes.get(4).addNodes(nodes.get(6));
+
+        treeModel = new TreeModel(MiningFunctionType.CLASSIFICATION, new MiningSchema(), nodes.get(0));
+    }
+
+    class IndexCollector extends AbstractVisitor {
+        Set<Integer> indices = new HashSet<>();
+
+        @Override
+        public VisitorAction visit(Node node) {
+            Integer ind = Integer.parseInt(node.getId());
+            indices.add(ind);
+
+            return super.visit(node);
+        }
+
+        public Set<Integer> getIndices() {
+            return indices;
+        }
+    }
+
+    @Test
+    public void indexNodesTest() {
+
+        IndexCollector indexCollector = new IndexCollector();
+
+        TreeModelUtil.indexNodes(treeModel);
+
+        indexCollector.applyTo(treeModel);
+
+        Set<Integer> actual = indexCollector.getIndices();
+        Set<Integer> expected = new HashSet(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+
+        assertEquals(true, actual.equals(expected));
+    }
+}


### PR DESCRIPTION
When we tried importing a .pmml file for a DecisionTree into KNIME, we noticed that KNIME needs Node ID tags for each Node in the DecisionTree which were missing in the exported file.

This is an attempt to fix this problem: 
In TreeModelUtil.java we provide a function which uses a visitor object to visit every Node of a TreeModel and set their IDs to the value of a running index.
In DecisionTreeClassificationModelConverter.java we call this function after the creation of the treeModel object.

Please advise.