### PR TITLE
Upgrade spark to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,19 @@
 		<url>https://github.com/jpmml/jpmml-sparkml/issues</url>
 	</issueManagement>
 
+	<properties>
+		<java.version>1.7</java.version>
+		<spark.version>2.1.1</spark.version>
+		<jcommander.version>1.48</jcommander.version>
+		<jpmml.converter.version>1.2.3</jpmml.converter.version>
+		<jpmml.evaluator.version>1.3.6</jpmml.evaluator.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.beust</groupId>
 			<artifactId>jcommander</artifactId>
-			<version>1.48</version>
+			<version>${jcommander.version}</version>
 		</dependency>
 
 		<dependency>
@@ -58,7 +66,7 @@
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-mllib_2.11</artifactId>
-			<version>2.1.0</version>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -71,7 +79,7 @@
 		<dependency>
 			<groupId>org.jpmml</groupId>
 			<artifactId>jpmml-converter</artifactId>
-			<version>1.2.3</version>
+			<version>${jpmml.converter.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.guava</groupId>
@@ -106,13 +114,13 @@
 		<dependency>
 			<groupId>org.jpmml</groupId>
 			<artifactId>pmml-evaluator</artifactId>
-			<version>1.3.5</version>
+			<version>${jpmml.evaluator.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jpmml</groupId>
 			<artifactId>pmml-evaluator-test</artifactId>
-			<version>1.3.5</version>
+			<version>${jpmml.evaluator.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -124,8 +132,9 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Upgrade Spark to 2.1.1, jpmml.evaluator to 1.3.6,
2. Support user  build jpmml-sparkml against the specific Spark version in they environment:
```bash
mvn clean install -Dspark.version=2.1.0
```