### PR TITLE
Use majority vote for RandomForest segmentations (#36)

### DIFF
--- a/src/main/java/org/jpmml/sparkml/model/RandomForestClassificationModelConverter.java
+++ b/src/main/java/org/jpmml/sparkml/model/RandomForestClassificationModelConverter.java
@@ -43,7 +43,7 @@ public class RandomForestClassificationModelConverter extends ClassificationMode
 		List<TreeModel> treeModels = TreeModelUtil.encodeDecisionTreeEnsemble(model, schema);
 
 		MiningModel miningModel = new MiningModel(MiningFunction.CLASSIFICATION, ModelUtil.createMiningSchema(schema.getLabel()))
-			.setSegmentation(MiningModelUtil.createSegmentation(Segmentation.MultipleModelMethod.AVERAGE, treeModels));
+			.setSegmentation(MiningModelUtil.createSegmentation(Segmentation.MultipleModelMethod.MAJORITY_VOTE, treeModels));
 
 		return miningModel;
 	}

--- a/src/main/java/org/jpmml/sparkml/model/RandomForestRegressionModelConverter.java
+++ b/src/main/java/org/jpmml/sparkml/model/RandomForestRegressionModelConverter.java
@@ -43,7 +43,7 @@ public class RandomForestRegressionModelConverter extends RegressionModelConvert
 		List<TreeModel> treeModels = TreeModelUtil.encodeDecisionTreeEnsemble(model, schema);
 
 		MiningModel miningModel = new MiningModel(MiningFunction.REGRESSION, ModelUtil.createMiningSchema(schema.getLabel()))
-			.setSegmentation(MiningModelUtil.createSegmentation(Segmentation.MultipleModelMethod.AVERAGE, treeModels));
+			.setSegmentation(MiningModelUtil.createSegmentation(Segmentation.MultipleModelMethod.MAJORITY_VOTE, treeModels));
 
 		return miningModel;
 	}


### PR DESCRIPTION
Spark's RandomForests are evaluated using majority vote for it's segmentation.