### PR TITLE
Fix stringindexermodel missing value issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Java library and command-line application for converting Apache Spark ML pipelin
 
 JPMML-SparkML library JAR file (together with accompanying Java source and Javadocs JAR files) is released via [Maven Central Repository](https://repo1.maven.org/maven2/org/jpmml/).
 
-The current version is **1.5.9** (23 June, 2020).
+The current version is **1.5.10** (26 December, 2020).
 
 ```xml
 <dependency>
 	<groupId>org.jpmml</groupId>
 	<artifactId>jpmml-sparkml</artifactId>
-	<version>1.5.9</version>
+	<version>1.5.10</version>
 </dependency>
 ```
 

--- a/src/main/java/org/jpmml/sparkml/feature/StringIndexerModelConverter.java
+++ b/src/main/java/org/jpmml/sparkml/feature/StringIndexerModelConverter.java
@@ -30,6 +30,7 @@ import org.dmg.pmml.DataType;
 import org.dmg.pmml.DerivedField;
 import org.dmg.pmml.Field;
 import org.dmg.pmml.InvalidValueTreatmentMethod;
+import org.dmg.pmml.MissingValueTreatmentMethod;
 import org.dmg.pmml.OpType;
 import org.dmg.pmml.PMMLFunctions;
 import org.dmg.pmml.Value;
@@ -37,6 +38,7 @@ import org.jpmml.converter.CategoricalFeature;
 import org.jpmml.converter.Feature;
 import org.jpmml.converter.FieldNameUtil;
 import org.jpmml.converter.InvalidValueDecorator;
+import org.jpmml.converter.MissingValueDecorator;
 import org.jpmml.converter.PMMLUtil;
 import org.jpmml.sparkml.FeatureConverter;
 import org.jpmml.sparkml.SparkMLEncoder;
@@ -78,6 +80,7 @@ public class StringIndexerModelConverter extends FeatureConverter<StringIndexerM
 			DataField dataField = (DataField)field;
 
 			InvalidValueDecorator invalidValueDecorator;
+			MissingValueDecorator missingValueDecorator;
 
 			switch(handleInvalid){
 				case "keep":
@@ -87,6 +90,10 @@ public class StringIndexerModelConverter extends FeatureConverter<StringIndexerM
 						PMMLUtil.addValues(dataField, Collections.singletonList(invalidCategory), Value.Property.INVALID);
 
 						categories.add(invalidCategory);
+
+						missingValueDecorator = new MissingValueDecorator(MissingValueTreatmentMethod.AS_VALUE, invalidCategory);
+
+						encoder.addDecorator(dataField, missingValueDecorator);
 					}
 					break;
 				case "error":


### PR DESCRIPTION
add missingValueReplacement="__unknown" missingValueTreatment="asValue" in jpmml MiningField to avoid evaluation failed when the string field is missed.